### PR TITLE
Accept all negative values, not just -1

### DIFF
--- a/lib/kiwf.js
+++ b/lib/kiwf.js
@@ -1,32 +1,32 @@
 module['exports'] = function (options) {
 
   options = options || {};
-  
+
   //
-  // maxMemory - represents maximum memory process can handle before exiting 
+  // maxMemory - represents maximum memory process can handle before exiting
   //
   // note: a negative value will indicate infinite memory
   //
-  options.maxMemory = options.maxMemory  || -1;
-  
+  options.maxMemory = options.maxMemory  || Infinity;
+
   //
   // Bind maxMemory to process ( for reference )
   //
   process.maxMemory = options.maxMemory;
-  
+
   //
   // maxUptime - determines how long the application will stay up for
-  // 
+  //
   // note: a negative value will indicate infinite maxUptime
   //
-  options.maxUptime = options.maxUptime || -1;
+  options.maxUptime = options.maxUptime || Infinity;
   options.startTime = new Date().getTime();
 
   //
   // Bind maxMemory to process ( for reference )
   //
   process.maxUptime = options.maxUptime;
-  
+
   //
   // interval - value that we will check all kill conditions
   //
@@ -37,7 +37,7 @@ module['exports'] = function (options) {
     //
     // Memory
     //
-    if (options.maxMemory && options.maxMemory !== -1) {
+    if (options.maxMemory && options.maxMemory >= 0) {
       var mem = process.memoryUsage().rss;
       if (mem >= options.maxMemory) {
         kill('maxMemory has been exceeded.');
@@ -47,7 +47,7 @@ module['exports'] = function (options) {
     //
     // Uptime
     //
-    if (options.maxUptime && options.maxUptime !== -1) {
+    if (options.maxUptime && options.maxUptime >= 0) {
       var currentTime = new Date().getTime();
       if (currentTime - options.startTime >= options.maxUptime) {
         kill('maxUptime has been exceeded.');


### PR DESCRIPTION
Hi,

I updated the code to accept any negative value (as it is defined in the Readme), currently only -1 was hardcoded. And in addition to that, I changed the default values to `Infinity` - it is a number just like any other but always larger than any finite number.

Andris

ps. my code editor trimmed whitespace from the line endings, creating a bit cluttered diff. sorry for that.
